### PR TITLE
Created TileDisplay component

### DIFF
--- a/app/javascript/components/TileDisplay.css
+++ b/app/javascript/components/TileDisplay.css
@@ -1,0 +1,18 @@
+/*Note this styling still has known errors*/
+
+.moduleRow {
+	width: 90%;
+	height: 150px;
+	margin: auto;
+}
+
+.moduleItem {
+	width: 150px;
+	float: left;
+	margin-right: calc( (90% - 750px)/4 );
+}
+
+.moduleSpan {
+	float: left;
+	width: 0px;
+}

--- a/app/javascript/components/TileDisplay.js
+++ b/app/javascript/components/TileDisplay.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import Tile from "./Tile";
+import { Link } from "react-router-dom";
+import "./TileDisplay.css";
+
+// To use this class an array of the following Module class is expected
+
+// class Module {
+//   constructor(imageKey, path) {
+//     this.imageKey = imageKey;
+//     this.path = path;
+//   }
+// }
+
+//Ex. component call <TileDisplay modules={[module1,module2,module3,module4]}/>
+
+class TileDisplay extends React.Component {
+   constructor(props) {
+      super(props);
+   }
+
+   createModules(moduleItem) {
+      return (
+      <Link className="moduleItem" key={moduleItem.imageKey + 1} to={moduleItem.path}>
+         <span className="moduleSpan" > 
+            <Tile imgKey={moduleItem.imageKey} key={moduleItem.imageKey}/> 
+         </span> 
+      </Link>
+      )
+  }
+
+   render() {
+     var moduleEntries = this.props.modules;
+     var listModules = moduleEntries.map(this.createModules);
+
+     return (
+         <div className="moduleRow">
+            {listModules}
+         </div>
+      )
+   }
+}
+
+export default TileDisplay;


### PR DESCRIPTION
Created TitleDisplay component #5  that expects an array of Module objects that takes the imageKey and path. The template of the class was included in the TitleDisplay file for easy future implementation. The first two screen shots work to demonstrate that the desired grid format is achieved. 

**Note**

- There are no internal checks to ensure that only 5 items will be placed into the array

- There are known issues with the formatting that will need to be resolved but for the sake of time will be pushed back and created as an additional issue #20 . (1) The display currently is slight off center with additional space on the right side. (2) When the screen size is reduce drastically the tiles overlap. 

<img width="1280" alt="Screen Shot 2020-09-02 at 11 56 37 PM" src="https://user-images.githubusercontent.com/23414761/92082084-f164e080-ed78-11ea-8e4f-032cdcbc665d.png">
<img width="1280" alt="Screen Shot 2020-09-02 at 11 57 05 PM" src="https://user-images.githubusercontent.com/23414761/92082073-ee69f000-ed78-11ea-90c0-b2c7fd9d208b.png">

**Known formatting issue**

<img width="692" alt="Screen Shot 2020-09-02 at 11 57 28 PM" src="https://user-images.githubusercontent.com/23414761/92082080-f033b380-ed78-11ea-9662-13d4fc9f672d.png">

